### PR TITLE
docs: document the AI Coach as this fork's feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@ frontend/dist/
 node_modules/
 *.log
 .DS_Store
+
+# Local AI-assistant tooling — contributor's own setup, not part of the app
+.claude/
+.codex/
+CLAUDE.md
+AGENTS.md
+graphify-out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,13 @@ own server, under your own provider account, and it is off until an admin turns 
 - ⭐ **How did that feel?** An optional one-tap rating on the finish summary — too easy / about
   right / brutal, plus a note. The Coach reads both.
 
-**For whoever runs the instance.** The provider CLI ships inside the api image, so there is
-nothing to install. Enable the Coach, connect an account and set spending caps entirely from
-the admin dashboard — no `.env` editing, no restart. The card shows CLI version, sign-in state,
-jobs run today and the last failure; it never shows anybody's intake answers, payloads or
-proposals. A **Fixture** provider walks the entire loop with no AI account at all.
+**For whoever runs the instance.** Both provider runtimes — Claude's Agent SDK and a pinned
+OpenAI Codex CLI — ship inside the api image, so there is nothing to install and neither path
+needs an API key. Enable the Coach, sign in (a `claude setup-token` you paste, or Codex's
+ChatGPT device-code flow) and set spending caps entirely from the admin dashboard — no `.env`
+editing, no restart. The card shows runtime version, sign-in state, jobs run today and the last
+failure; it never shows anybody's intake answers, payloads or proposals. A **Fixture** provider
+walks the entire loop with no AI account at all.
 
 **For everyone else.** An instance with the Coach switched off is the app it was before, to the
 byte: no new UI, no new requests, no change to the state you sync. Turning it on adds one
@@ -55,10 +57,16 @@ feature does not enable it for you. The consent screen lists exactly which categ
 leave the server, names the provider, and says whose account pays. The mobile build has no
 server and hides it; the demo runs it against a canned local provider so you can try the loop.
 
-Under the hood: the CLI runs as an unprivileged user that cannot read `./data`, with a scrubbed
-environment and no tools; every answer is validated against a closed list of change types and
-the real exercise library before anyone sees it, with one repair round and then a clean
-failure. Credentials are encrypted at rest with a key derived from the instance secret.
+Under the hood: the provider runtime runs as an unprivileged user that cannot read `./data`,
+with a scrubbed environment and no tools; every answer is validated against a closed list of
+change types and the real exercise library before anyone sees it, with one repair round and
+then a clean failure. A pasted Claude setup token is encrypted at rest with a key derived from
+the instance secret; Codex's ChatGPT credential stays in Codex's own private cache, mounted
+separately from app data and never copied into `coach.json`.
+
+Documented in **[docs/AI_COACH.md](docs/AI_COACH.md)**, with setup walkthroughs for
+[Claude](Claude-setup-instructions.md) and [ChatGPT/Codex](ChatGPT-setup-instructions.md) and
+the design rationale in [openGym_AI_Strategy.pdf](openGym_AI_Strategy.pdf).
 
 ### The effort ratings, read back as statistics
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ No account on someone else's server, no subscription, no ads. Just `docker compo
 
 <br>
 
+> ### 🤖 This is a fork — it adds the AI Coach
+>
+> A fork of [DuarteSantos8/openGym](https://github.com/DuarteSantos8/openGym) that adds one
+> optional feature: an AI that **designs** your training plan and **revises it from what you
+> actually log**, running on your own server under your own provider account.
+>
+> Everything else is upstream openGym. With the Coach switched off, this is byte-for-byte the
+> app it forked from.
+>
+> **→ [What it does and how to use it](docs/AI_COACH.md)** ·
+> [Claude setup](Claude-setup-instructions.md) ·
+> [ChatGPT / Codex setup](ChatGPT-setup-instructions.md) ·
+> [design deck (PDF)](openGym_AI_Strategy.pdf)
+
+<br>
+
 <div align="center">
 <table>
 <tr>
@@ -73,7 +89,7 @@ as a home-screen app, passkey sign-in, offline support, sync across your phone a
 - 🟩 **Activity heatmap** — a GitHub-style year view, shaded by time spent training
 - 💪 **Muscle map** — a front-and-back body diagram shaded by how much work each muscle got, over a week, a month or all time. It names the muscles you *haven't* trained in that period, previews what a routine hits while you build it, and shows what you just trained when you finish. Male or female figure, your pick
 - 🔔 **Push notifications** — rest-timer alerts even with the app closed, plus an optional reminder on days you have a workout planned but haven't logged one. Opt in per profile; keys are generated on first run, nothing to configure
-- 🤖 **AI Coach** (optional) — an AI that *designs* your plan and adjusts it from what you actually log. A short intake produces a complete weekly plan you can refine in plain language; on demand or on a schedule it reads your stalls, effort ratings, adherence and body-weight trend and proposes **discrete, explained changes** you accept one by one. Choose the official Claude Agent SDK or the bundled OpenAI Codex CLI with ChatGPT device-code sign-in; it is off until the instance owner enables it, needs each profile's separate consent, and never changes anything without your approval — every change-set is snapshotted and revertible. The progression engine still owns your session-to-session weights
+- 🤖 **AI Coach** (optional) — an AI that *designs* your plan and adjusts it from what you actually log. A short intake produces a complete weekly plan you can refine in plain language; on demand or on a schedule it reads your stalls, effort ratings, adherence and body-weight trend and proposes **discrete, explained changes** you accept one by one. Choose the official Claude Agent SDK or the bundled OpenAI Codex CLI with ChatGPT device-code sign-in; it is off until the instance owner enables it, needs each profile's separate consent, and never changes anything without your approval — every change-set is snapshotted and revertible. The progression engine still owns your session-to-session weights. **[Full guide →](docs/AI_COACH.md)**
 - 🔑 **Passkeys, not passwords** — Face ID / Touch ID / fingerprint login; each profile keeps its own data, synced across devices
 - 🛠️ **Admin dashboard** (optional) — for whoever runs the instance: who's training right now, per-user history, disable accounts, and invite-only signup. Off by default, so a fresh instance stays open with no admin
 - 🎨 **Designed, not assembled** — light/dark themes and 8 accent colors saved to your profile, over a hand-drawn icon set instead of emoji, so it looks the same on every phone
@@ -159,8 +175,9 @@ Push notification keys are generated on first run and saved to `./data/vapid.jso
 
 The **AI Coach** needs no `.env` at all: Claude's Agent SDK and a pinned OpenAI Codex CLI ship
 inside the api image. An admin can add a Claude Code setup token or complete Codex's ChatGPT
-device-code sign-in in the dashboard. See [the self-hosting guide](docs/SELF_HOSTING.md#8-the-ai-coach-optional)
-and [the ChatGPT/Codex setup guide](ChatGPT-setup-instructions.md).
+device-code sign-in in the dashboard. See [the AI Coach guide](docs/AI_COACH.md),
+[the self-hosting guide](docs/SELF_HOSTING.md#8-the-ai-coach-optional), and the setup
+walkthroughs for [Claude](Claude-setup-instructions.md) and [ChatGPT/Codex](ChatGPT-setup-instructions.md).
 
 ## Roadmap
 

--- a/docs/AI_COACH.md
+++ b/docs/AI_COACH.md
@@ -1,0 +1,179 @@
+# The AI Coach
+
+The feature this fork adds to [openGym](https://github.com/DuarteSantos8/openGym): an optional AI
+that **designs** your training plan and **revises it from what you actually log** — running as a
+CLI on your own server, under your own provider account, off until an admin turns it on.
+
+> The smartest coach is the one running on your own machine.
+
+---
+
+## Why it exists
+
+Upstream openGym progresses a plan flawlessly and cannot write one. The engine adjusts weights
+inside whatever structure you built, and the effort ratings you log — RIR, RPE — were, by the
+app's own admission, read by nothing. Adherence, stalls and muscle gaps were all *displayed* and
+never synthesised into a decision.
+
+The Coach does the two jobs the engine deliberately doesn't: it designs plans, and it changes
+them when your training says they should change.
+
+## The boundary that makes it safe
+
+The split is the whole design. Judgement and math live in different places, and the AI never
+crosses into the math.
+
+| The Coach — where judgement lives | The Engine — where math lives |
+| --- | --- |
+| Creates weekly routines | Computes tomorrow's bar weight |
+| Sets progression policies | Strictly deterministic |
+| Reads RPE / RIR | Applies linear / Greyskull progression |
+| Interprets plain-text feedback | Tracks strict hit/miss |
+| Adds and swaps exercises | Manages `exWeights` |
+
+**The Coach configures the plan. The Engine calculates the load.** If the AI times out or the
+provider dies, the engine carries on offline without skipping a beat.
+
+## Principles
+
+- **Your box, your data.** The provider runs locally; openGym ships no bundled API keys.
+- **Opt in twice.** An admin enables the feature; each profile consents separately before any of
+  its data is used.
+- **Approval required.** Proposals are inert until you tap Apply, one change at a time.
+- **Nothing is one-way.** Applying snapshots your plan first; one tap reverts it. Reverting never
+  touches a logged workout — the log is what happened.
+- **Auditable.** Every trigger, payload summary and decision lands in a per-profile Coach log
+  that syncs and travels in your JSON backup.
+- **Degrade gracefully.** With the Coach off, the app is byte-for-byte what it was before.
+
+---
+
+## Providers that ship today
+
+| Provider | Runtime | How you sign in | Guide |
+| --- | --- | --- | --- |
+| **Claude Code** | Claude Agent SDK | `claude setup-token` on a trusted machine, pasted into the admin card | [Claude setup guide](../Claude-setup-instructions.md) |
+| **OpenAI Codex** | Codex CLI (pinned, bundled) | ChatGPT device-code sign-in from the admin card | [ChatGPT / Codex setup guide](../ChatGPT-setup-instructions.md) |
+| **Fixture** | in-repo fake | nothing — no AI account at all | walks the whole loop for demos and CI |
+
+Both runtimes are built into the `api` image, so a self-hoster installs nothing. Neither path
+needs an API key. openGym never handles a browser OAuth callback and never asks your users for
+credentials.
+
+> **Note.** The design deck describes a provider-agnostic surface including Gemini and an
+> owner-supplied custom command. Those adapters were built and then retired before release; a
+> stored configuration pointing at either resets to an unconfigured Claude. Adding a provider is
+> still one adapter file plus one row in `api/coach/config.js` — nothing else branches on
+> provider identity.
+
+---
+
+## Using it
+
+### If you run the instance
+
+1. Enable the Coach and sign in a provider from **Settings → Admin → AI Coach**. No `.env`
+   editing, no restart.
+2. Set per-profile and instance-wide daily caps *before* inviting people — every plan or review
+   is one session billed to the account you connected.
+3. The card shows runtime version, sign-in state, jobs run today and the last failure. It never
+   shows anyone's intake answers, payloads or proposals.
+
+Full walkthrough: [Claude](../Claude-setup-instructions.md) · [ChatGPT / Codex](../ChatGPT-setup-instructions.md) ·
+[self-hosting §8](SELF_HOSTING.md#8-the-ai-coach-optional).
+
+`COACH_DISABLED=1` is the kill switch: the Coach reports as disabled everywhere regardless of
+what is stored — useful for a fleet.
+
+### If you train on it
+
+**Journey 1 — get a plan.** A six-screen intake (goal, experience, days, session length,
+equipment, limitations, likes and dislikes) produces a complete weekly plan: routines, exercise
+selection, sets × reps, supersets, the week schedule, and a progression policy per routine. Every
+exercise carries a sentence on why it is there. Don't like it? Say so in plain language — *"swap
+the squats for split squats, Mondays are short"* — and the plan comes back revised. Applying it
+behaves exactly like importing a plan file.
+
+**Journey 2 — the feedback loop.** On demand, weekly, or after every N sessions, the Coach reads
+your recent evidence — sets hit and missed against target, effort trends, stalls and deloads the
+engine fired, sessions you keep moving, session length against the time you said you had, body
+weight against your goal, and muscle groups that got nothing — and returns a list of **discrete
+changes**, each with a before → after and a rationale naming the evidence:
+
+> *"Bench came in at RPE ≥ 9.5 for three sessions and stalled twice; swapping to dumbbell press
+> for four weeks."*
+
+Tick the ones you want and hit **Apply & Snapshot**. Advice with no plan change attached goes to a
+notes section and applies nothing. A review that finds no reason to change anything says so and
+sends no notification. Suggestions you turn down are remembered, so the next review doesn't
+re-propose them without new evidence.
+
+---
+
+## What actually leaves your server
+
+`api/coach/payload.js` is built as an allowlist: every field is copied in **by name**, nothing is
+spread and nothing is passed through, so a field added to the state blob next year cannot ride
+along by accident. The five categories it can send — the same list the consent screen renders
+from, so the screen cannot drift from the payload — are:
+
+| Category | What it covers |
+| --- | --- |
+| `plan` | routines, exercises, sets/reps, schedule, progression settings |
+| `training` | logged sets, targets, effort ratings, durations, PRs in the review window |
+| `bodyweight` | weigh-ins in the window and your goal weight |
+| `profile` | the intake answers you gave the Coach, including any limitations |
+| `prefs` | unit, language, effort scale |
+
+A review reads a training block, not a training career: the window is capped at **12 weeks or 60
+sessions**. Your profile is identified by a stable pseudonym that is never the user id and never
+reversible.
+
+Excluded on purpose and permanently: **display name and user id, passkey and credential
+material, push subscriptions, invite data, theme and appearance settings, and every other
+profile's everything.** Only the math and the effort leave the box.
+
+## Guardrails
+
+- **Persistent memory.** A stated limitation — *"bad right shoulder"* — persists in the Coach
+  profile, and every later proposal respects it.
+- **Conservative by design.** If pain shows up in free text the Coach will not diagnose. It
+  programs conservatively and points you at a professional.
+- **Validated before you see it.** Every answer is checked against a closed list of change types
+  and the real exercise library — one repair round, then a clean failure. This validator, not the
+  prompt, is the security boundary.
+- **Contained.** Jobs run as an unprivileged user that cannot read `./data`, with an environment
+  built from nothing rather than filtered. Codex's ChatGPT credential stays in its own private
+  cache (mounted separately from app data), never in `coach.json`; Claude's setup token is
+  encrypted at rest with a key derived from the instance secret.
+
+## Deliberately out of scope
+
+- No AI overriding a per-session load — the engine owns the math.
+- No live mid-workout chat or real-time set advice — sessions stay distraction-free.
+- No form-video analysis or biomechanical diagnostics — payloads stay minimal.
+- No AI in browser-only guest mode — the zero-telemetry promise holds.
+
+---
+
+## Where the code lives
+
+```
+api/coach/            config, jobs, payload allowlist, validator, prompts, adapters
+frontend/src/lib/coach.js        plan fingerprint, snapshots, atomic apply, revert
+frontend/src/views/Coach*.jsx    hub, intake, proposal review
+frontend/src/views/AdminCoach.jsx  provider, sign-in, caps, health
+```
+
+## Design documents
+
+- **[openGym_AI_Strategy.pdf](../openGym_AI_Strategy.pdf)** — the functional description and
+  design rationale for the feature (Implementation Plan v1.3.0), as a slide deck: the problem,
+  the Coach/Engine boundary, persona boundaries, both user journeys, the trust model and the
+  delivery phasing. Read this first for the *why*; read this file for what shipped.
+- **[ai-enablement/functional-plan.md](../ai-enablement/functional-plan.md)** — numbered
+  functional requirements (the `FR-xx` ids referenced throughout the code).
+- **[ai-enablement/implementation-plan.md](../ai-enablement/implementation-plan.md)** — the build
+  plan.
+- **[ai-enablement/implementation-report.md](../ai-enablement/implementation-report.md)** — what
+  was actually built, and where it diverged.


### PR DESCRIPTION
## Summary
- **`docs/AI_COACH.md`** (new) — the canonical feature doc for this fork: why it exists, the Coach/Engine boundary, the providers that actually ship, both user journeys, what leaves your server, guardrails, out-of-scope, code map, and design documents. Links to the existing Claude and ChatGPT setup walkthroughs rather than restating them.
- **README** — a fork notice at the top: what this adds, that everything else is upstream, and the entry points.
- **CHANGELOG** — the `Unreleased` entry still described the pre-Agent-SDK design (one bundled provider CLI, browser OAuth, credentials uniformly encrypted at rest). Corrected in place, since it has not shipped.
- **`.gitignore`** — ignore local AI-assistant tooling so the fork's diff against upstream stays exactly the AI Coach feature.

Two things the docs say that the design deck does not: Gemini and the custom-command adapter were built then retired, so the shipped set is Claude / Codex / test fixture; and the "what leaves your server" section is written from `api/coach/payload.js` (five consent categories, 12-week / 60-session window, pseudonymous profile id) rather than from the deck's slide.

## Test plan
- [x] API tests: 56/56 pass
- [x] Frontend tests: 207/207 pass
- [x] Locale parity: 11 locales × 781 keys, in sync
- [x] Production build succeeds; `docker compose config` valid
- [x] All 29 relative doc links verified resolving
- [x] Secret scan over tracked files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnXPdnec721S6ZrQJGzAfq